### PR TITLE
`Promise.all`-like typed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ client.exec([
   app.getServerIP()
 ]).then(res => {
   // res will be like this:
-  // {
-  //  appName: "xhip example",
-  //  appVersion: 1,
-  //  say: hi,
-  //  ip: ***.***.***.***
-  // }
+  // [
+  //   {appName: "xhip example"},
+  //   {appVersion: 1},
+  //   {say: hi},
+  //   {ip: ***.***.***.***},
+  // ]
 })
 ```
 
@@ -115,9 +115,9 @@ You can inquiry this way:
 ```
 {
   "__xhip": true,
-  "operations": {
-    "your_operation": argument
-  }
+  "operations": [
+    {"your_operation": argument}
+  ]
 }
 ```
 then server must return this way:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "pretest": "lerna exec -- npm install",
+    "pretest": "lerna bootstrap",
     "test": "lerna run test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "test": "lerna run test"
   },
   "devDependencies": {
-    "lerna": "2.0.0-beta.37"
+    "lerna": "2.0.0-beta.37",
+    "typescript": "^2.1.6"
   }
 }

--- a/packages/xhip-client/package.json
+++ b/packages/xhip-client/package.json
@@ -25,7 +25,7 @@
     "mocha": "^3.2.0",
     "sinon": "^1.17.7",
     "typescript": "^2.1.4",
-    "xhip": "0.0.7"
+    "xhip": "../xhip"
   },
   "dependencies": {
     "@types/whatwg-fetch": "0.0.33",

--- a/packages/xhip-client/package.json
+++ b/packages/xhip-client/package.json
@@ -25,7 +25,7 @@
     "mocha": "^3.2.0",
     "sinon": "^1.17.7",
     "typescript": "^2.1.4",
-    "xhip": "../xhip"
+    "xhip": "^0.1.0"
   },
   "dependencies": {
     "@types/whatwg-fetch": "0.0.33",

--- a/packages/xhip-client/src/index.ts
+++ b/packages/xhip-client/src/index.ts
@@ -33,7 +33,7 @@ export class Client {
   get isSocketOpen() {
     return this.socket.readyState === WebSocket.OPEN
   }
-  subscribe<T>(target: () => Promise<T>, receiver: (value: T) => void) {
+  subscribe<T>(target: (...args: any[]) => Promise<T>, receiver: (value: T) => void) {
     this.subscriptions.push({
       target,
       receiver

--- a/packages/xhip-client/test/index.test.ts
+++ b/packages/xhip-client/test/index.test.ts
@@ -2,26 +2,34 @@ import { Client } from "../src/index"
 import * as sinon from "sinon"
 import { assert } from "chai"
 import * as fetchMock from "fetch-mock"
+import {Application, op} from "xhip"
 
 fetchMock.post("*", JSON.stringify(
   [{
-    b: "a"
+    a: "b"
   }]
 ))
 
 global["URL"] = sinon.mock()
 global["WebSocket"] = sinon.mock()
 
+class Test extends Application {
+  @op async a() {
+    return {a: "b"}
+  }
+}
+
 console.log(fetch)
 
 describe('Client', () => {
   describe('exec', () => {
     it('should creatable from test', async () => {
-        const client = new Client("http://www.example.com/", { ssl: false })
-        const result = await client.exec([{ a: "a" }])
-        assert.deepEqual(result, {
-        b: "a"
-        })
+      const client = new Client("http://www.example.com/", { ssl: false })
+      const app = new Test()
+      const [result] = await client.exec([app.a()])
+      assert.deepEqual(result, {
+        a: "b"
+      })
     })
   })
 })

--- a/packages/xhip-client/test/index.test.ts
+++ b/packages/xhip-client/test/index.test.ts
@@ -3,11 +3,11 @@ import * as sinon from "sinon"
 import { assert } from "chai"
 import * as fetchMock from "fetch-mock"
 
-fetchMock.post("*", JSON.stringify({
-    a: {
-        b: "a"
-    }
-}))
+fetchMock.post("*", JSON.stringify(
+  [{
+    b: "a"
+  }]
+))
 
 global["URL"] = sinon.mock()
 global["WebSocket"] = sinon.mock()
@@ -15,13 +15,13 @@ global["WebSocket"] = sinon.mock()
 console.log(fetch)
 
 describe('Client', () => {
-    describe('exec', () => {
-        it('should creatable from test', async () => {
-            const client = new Client("http://www.example.com/", { ssl: false })
-            const result = await client.exec([{ a: "a" }])
-            assert.deepEqual(result, {
-                b: "a"
-            })
+  describe('exec', () => {
+    it('should creatable from test', async () => {
+        const client = new Client("http://www.example.com/", { ssl: false })
+        const result = await client.exec([{ a: "a" }])
+        assert.deepEqual(result, {
+        b: "a"
         })
     })
+  })
 })

--- a/packages/xhip-server/package.json
+++ b/packages/xhip-server/package.json
@@ -28,7 +28,7 @@
     "request": "^2.79.0",
     "sinon": "^1.17.7",
     "typescript": "^2.1.4",
-    "xhip": "../xhip"
+    "xhip": "^0.1.0"
   },
   "dependencies": {
     "@types/cors": "^2.8.0",

--- a/packages/xhip-server/package.json
+++ b/packages/xhip-server/package.json
@@ -27,7 +27,8 @@
     "mocha": "^3.2.0",
     "request": "^2.79.0",
     "sinon": "^1.17.7",
-    "typescript": "^2.1.4"
+    "typescript": "^2.1.4",
+    "xhip": "../xhip"
   },
   "dependencies": {
     "@types/cors": "^2.8.0",
@@ -35,8 +36,7 @@
     "body-parser": "^1.15.2",
     "cors": "^2.8.1",
     "express": "^4.14.0",
-    "express-ws": "^2.0.0",
-    "xhip": "^0.0.24"
+    "express-ws": "^2.0.0"
   },
   "version": "0.1.0"
 }

--- a/packages/xhip-server/src/index.ts
+++ b/packages/xhip-server/src/index.ts
@@ -4,7 +4,7 @@ import * as http from "http"
 import * as cors from "cors"
 import * as ws from "ws"
 
-import {OperationFunction} from "xhip"
+import {OperationFunction, OperationFunctionResult} from "xhip"
 
 const broadcastSymbol = Symbol()
 
@@ -27,7 +27,8 @@ export class Server {
         if (!req.body['operations']) {
           return res.sendStatus(200)
         }
-        const result = await this.getOperationResult(req.body['operations'], req)
+        const operations = req.body.operations as OperationFunctionResult[]
+        const result = await Promise.all(operations.map(op => this.getOperationResult(op, req)))
         res.json(result)
       } else {
         return res.sendStatus(400)
@@ -50,24 +51,20 @@ export class Server {
       return this.lookupOperationFunction(context, operation, currentBase[protoName])
     return names.map(name => this.lookupOperationFunction(context, operation, currentBase[name]))[0] || null
   }
-  async getOperationResult(operations: any[], req: express.Request) {
+  async getOperationResult(op: OperationFunctionResult, req: express.Request) {
     let results = []
-    for (let op of operations) {
-      const {operation} = op
-      const {args} = op
-      const {context} = op
-      const operationFunction = this.lookupOperationFunction(context, operation)
-      if (!operationFunction) {
-        results.push({error: "operation not found"})
-        continue
-      }
-      const result = await operationFunction.operation.apply({req}, args)
-      results.push({
-        ...result,
-        [broadcastSymbol]: operationFunction[Symbol.for("broadcast")]
-      })
+    const {operation} = op
+    const {args} = op
+    const {context} = op
+    const operationFunction = this.lookupOperationFunction(context, operation)
+    if (!operationFunction) {
+      return {error: "operation not found"}
     }
-    return results
+    const result = await operationFunction.operation.apply({req}, args)
+    return {
+      ...result,
+      [broadcastSymbol]: operationFunction[Symbol.for("broadcast")]
+    }
   }
   listen(...args: any[]): http.Server {
     this.server = http.createServer(this.app)
@@ -85,9 +82,10 @@ export class Server {
     this.app['ws']('/ws', (ws: ws, req: express.Request) => {
       ws.on('message', async message => {
         try {
-          const results = await this.getOperationResult(JSON.parse(message)['operations'], req)
-          for (const result of results) {
-            const json = JSON.stringify(result)
+          const operations = JSON.parse(message).operations as OperationFunctionResult[]
+          for (const op of operations) {
+            const result = await this.getOperationResult(op, req)
+            const json = JSON.stringify({[op.operation]: result})
             if (result[broadcastSymbol]) {
               broadcast(json)
             } else {

--- a/packages/xhip-server/test/index.test.ts
+++ b/packages/xhip-server/test/index.test.ts
@@ -7,7 +7,7 @@ import { op, broadcast, Application } from "xhip"
 import * as WebSocket from "ws"
 
 class TestMixinMixin extends Application {
-  @op echo() {
+  @op async echo() {
     return {
       'this': 'is from TestMixinMixin'
     }
@@ -16,7 +16,7 @@ class TestMixinMixin extends Application {
 
 class TestMixin extends Application {
   testMixinMixin = new TestMixinMixin
-  @op echo() {
+  @op async echo() {
     return {
       'this': 'is from TestMixin'
     }
@@ -25,29 +25,29 @@ class TestMixin extends Application {
 
 class TestBaseApp extends Application {
   testMixin = new TestMixin()
-  @op showAppName() {
+  @op async showAppName() {
     return {
       "appName": "Xhip"
     }
   }
-  @op echo(say: any) {
+  @op async echo(say: any) {
     return {say}
   }
   @op asyncfn() {
     return Promise.resolve({ supportAsync: "yes" })
   }
-  @op ping() {
+  @op async ping() {
     return {
       "ping": "pong"
     }
   }
   @broadcast
-  @op broadcaster() {
+  @op async broadcaster() {
     return {
       "ping": "pong"
     }
   }
-  @op ip() {
+  @op async ip() {
     return {
       ip: this.req.ip
     }
@@ -107,14 +107,14 @@ describe('Server', () => {
       })
     }).then((res) => {
       assert.strictEqual(res.status, 200)
-      return res.json().then(x => assert.deepEqual(x, {
-        showAppName: {
+      return res.json().then(x => assert.deepEqual(x, [
+        {
           appName: "Xhip"
         }, 
-        echo: {
+        {
           say: 'hi'
         }
-      }))
+      ]))
     })
   })
   it('can replace req object as actual one', () => {
@@ -131,11 +131,11 @@ describe('Server', () => {
       })
     }).then((res) => {
       assert.strictEqual(res.status, 200)
-      return res.json().then(x => assert.deepEqual(x, {
-        ip: {
+      return res.json().then(x => assert.deepEqual(x, [
+        {
           ip: "::ffff:127.0.0.1"
         }
-      }))
+      ]))
     })
   })
   it('can search mixins', () => {

--- a/packages/xhip/src/index.ts
+++ b/packages/xhip/src/index.ts
@@ -35,7 +35,7 @@ export function broadcast(target: any, propertyKey?: string, descriptor?: Proper
   return descriptor
 }
 
-export function op<T>(target: any, propertyKey?: string, descriptor?: TypedPropertyDescriptor<() => Promise<T>>) {
+export function op<T>(target: any, propertyKey?: string, descriptor?: TypedPropertyDescriptor<(...args: any[]) => Promise<T>>) {
   if (!descriptor || !descriptor.value || !propertyKey)
     throw new TypeError("op decorator should apply to method")
   descriptor.value = new OperationFunction(descriptor.value, propertyKey, target) as any

--- a/packages/xhip/src/index.ts
+++ b/packages/xhip/src/index.ts
@@ -28,17 +28,17 @@ export class OperationFunction extends Function {
 export interface OperationFunction {
   (...args: any[]): OperationFunctionResult
 }
-export const broadcast = (target: any, propertyKey?: string, descriptor?: PropertyDescriptor) => {
+export function broadcast(target: any, propertyKey?: string, descriptor?: PropertyDescriptor) {
   if (!descriptor || !descriptor.value || !propertyKey)
     throw new TypeError("broadcast decorator should apply to method")
   descriptor.value[Symbol.for("broadcast")] = true
   return descriptor
 }
 
-export const op = (target: any, propertyKey?: string, descriptor?: PropertyDescriptor) => {
+export function op<T>(target: any, propertyKey?: string, descriptor?: TypedPropertyDescriptor<() => Promise<T>>) {
   if (!descriptor || !descriptor.value || !propertyKey)
     throw new TypeError("op decorator should apply to method")
-  descriptor.value = new OperationFunction(descriptor.value, propertyKey, target)
+  descriptor.value = new OperationFunction(descriptor.value, propertyKey, target) as any
   // Add static function accessing across client side
   return descriptor
 }

--- a/packages/xhip/src/index.ts
+++ b/packages/xhip/src/index.ts
@@ -25,6 +25,9 @@ export class OperationFunction extends Function {
     return fn as any as OperationFunction
   }
 }
+export interface OperationFunction {
+  (...args: any[]): OperationFunctionResult
+}
 export const broadcast = (target: any, propertyKey?: string, descriptor?: PropertyDescriptor) => {
   if (!descriptor || !descriptor.value || !propertyKey)
     throw new TypeError("broadcast decorator should apply to method")

--- a/packages/xhip/test/app.ts
+++ b/packages/xhip/test/app.ts
@@ -1,13 +1,13 @@
 import { op, broadcast, Application } from "../src/index"
 
 export class User extends Application {
-  @op getId() {
+  @op async getId() {
     return { id: 1 }
   }
 }
 
 export class Post extends Application {
-  @op getId() {
+  @op async getId() {
     return { id: 1 }
   }
 }
@@ -16,7 +16,7 @@ export class TestBaseApp extends Application {
   user = new User()
   post = new Post()
   @broadcast
-  @op getId() {
+  @op async getId() {
     return {}
   }
 }


### PR DESCRIPTION
* Typed `Client#exec` and `Client#send` like `Promise.all`
* `Client#subscribe` now subscribes one operation
* Force operation methods to return `Promise`

```ts
const res = await client.exec([
  app.showAppName(),
  app.showAppVersion(),
  app.echo("hi"),
  app.getServerIP()
])
// res will be like this:
// [
//   {appName: "xhip example"},
//   {appVersion: 1},
//   {say: hi},
//   {ip: ***.***.***.***}, 
// ]
```