### PR TITLE
1 method per exec/send and seemless error

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ export class App extends Application {
   @op echo(say) {
     return { say }
   }
+  @op throwError() {
+    throw new Error("error occured!!")
+  }
 }
 export const app = new App()
 ```
@@ -79,20 +82,11 @@ Client-side(client.js):
 import { Client } from "xhip-client"
 
 const client = new xhip.Client("http://localhost:8080/", { ssl: false })
-client.exec([
-  app.showAppName(),
-  app.showAppVersion(),
-  app.echo("hi"),
-  app.getServerIP()
-]).then(res => {
-  // res will be like this:
-  // [
-  //   {appName: "xhip example"},
-  //   {appVersion: 1},
-  //   {say: hi},
-  //   {ip: ***.***.***.***},
-  // ]
-})
+await client.exec(app.showAppName()) // => {appName: "xhip example"}
+await client.exec(app.showAppVersion()) // => {appVersion: 1}
+await client.exec(app.echo("hi") // => {say: hi}
+await client.exec(app.getServerIP()) // => {ip: ***.***.***.***}
+await client.exec(app.throwError()) // => throws {name: "Error", message: "error occured!!"}
 ```
 
 ## How it works
@@ -112,18 +106,20 @@ From client side, it will become to argument generator which will be posted into
 Xhip do everything in POST method.
 
 You can inquiry this way:
-```
+```json
 {
   "__xhip": true,
-  "operations": [
-    {"your_operation": argument}
-  ]
+  "operation": {"your_operation": argument}
 }
 ```
 then server must return this way:
-```
+```json
 {
-  "your_operation": result  
+  "result": result
+}
+or
+{
+  "error": error
 }
 ```
 

--- a/packages/xhip-client/src/index.ts
+++ b/packages/xhip-client/src/index.ts
@@ -8,14 +8,10 @@ export class Client {
   subscriptions: {key: string, receiver: (value: any) => void}[] = []
   constructor(public uri: string, public opts: { ssl: boolean }) {
   }
-  exec<T1>(ops: [Promise<T1>]): Promise<[T1]>
-  exec<T1, T2>(ops: [Promise<T1>, Promise<T2>]): Promise<[T1, T2]>
-  exec<T1, T2, T3>(ops: [Promise<T1>, Promise<T2>, Promise<T3>]): Promise<[T1, T2, T3]>
-  exec<T1, T2, T3, T4>(ops: [Promise<T1>, Promise<T2>, Promise<T3>, Promise<T4>]): Promise<[T1, T2, T3, T4]>
-  async exec(ops: Promise<any>[]) {
+  async exec<T>(op: Promise<T>) {
     const body = JSON.stringify({
       '__xhip': true,
-      'operations': ops
+      'operation': op
     })
     const res = await fetch(this.uri, {
       headers: {
@@ -29,7 +25,8 @@ export class Client {
     if (res.status >= 400) {
       return Promise.reject(res)
     }
-    return await res.json()
+    const result = await res.json()
+    return result as T
   }
   get isSocketOpen() {
     return this.socket.readyState === WebSocket.OPEN

--- a/packages/xhip-client/src/index.ts
+++ b/packages/xhip-client/src/index.ts
@@ -26,7 +26,11 @@ export class Client {
       return Promise.reject(res)
     }
     const result = await res.json()
-    return result as T
+    if (result.result) {
+      return result.result
+    } else {
+      throw result.error
+    }
   }
   get isSocketOpen() {
     return this.socket.readyState === WebSocket.OPEN

--- a/packages/xhip-client/src/index.ts
+++ b/packages/xhip-client/src/index.ts
@@ -37,14 +37,10 @@ export class Client {
       receiver
     })
   }
-  send<T1>(ops: [Promise<T1>]): void
-  send<T1, T2>(ops: [Promise<T1>, Promise<T2>]): void
-  send<T1, T2, T3>(ops: [Promise<T1>, Promise<T2>, Promise<T3>]): void
-  send<T1, T2, T3, T4>(ops: [Promise<T1>, Promise<T2>, Promise<T3>, Promise<T4>]): void
-  send(ops: Promise<any>[]) {
+  send<T>(op: Promise<T>) {
     if(this.isSocketOpen) {
       this.socket.send(JSON.stringify({
-        'operations': ops
+        'operation': op
       }))
     }
   }

--- a/packages/xhip-client/test/index.test.ts
+++ b/packages/xhip-client/test/index.test.ts
@@ -5,9 +5,9 @@ import * as fetchMock from "fetch-mock"
 import {Application, op} from "xhip"
 
 fetchMock.post("*", JSON.stringify(
-  [{
+  {
     a: "b"
-  }]
+  }
 ))
 
 global["URL"] = sinon.mock()
@@ -26,7 +26,7 @@ describe('Client', () => {
     it('should creatable from test', async () => {
       const client = new Client("http://www.example.com/", { ssl: false })
       const app = new Test()
-      const [result] = await client.exec([app.a()])
+      const result = await client.exec(app.a())
       assert.deepEqual(result, {
         a: "b"
       })

--- a/packages/xhip-client/test/index.test.ts
+++ b/packages/xhip-client/test/index.test.ts
@@ -4,12 +4,6 @@ import { assert } from "chai"
 import * as fetchMock from "fetch-mock"
 import {Application, op} from "xhip"
 
-fetchMock.post("*", JSON.stringify(
-  {
-    a: "b"
-  }
-))
-
 global["URL"] = sinon.mock()
 global["WebSocket"] = sinon.mock()
 
@@ -19,16 +13,43 @@ class Test extends Application {
   }
 }
 
-console.log(fetch)
-
 describe('Client', () => {
   describe('exec', () => {
-    it('should creatable from test', async () => {
-      const client = new Client("http://www.example.com/", { ssl: false })
-      const app = new Test()
-      const result = await client.exec(app.a())
-      assert.deepEqual(result, {
-        a: "b"
+    describe('when succeeds', () => {
+      it('should yield result', async () => {
+        fetchMock.postOnce("*", JSON.stringify({
+          result: {
+            a: "b"
+          }
+        }))
+        const client = new Client("http://www.example.com/", { ssl: false })
+        const app = new Test()
+        const result = await client.exec(app.a())
+        assert.deepEqual(result, {
+          a: "b"
+        })
+      })
+    })
+    describe('when fails', () => {
+      it('should throw error', async () => {
+        fetchMock.postOnce("*", JSON.stringify({
+          error: {
+            name: "Error",
+            message: "error!"
+          }
+        }))
+        const client = new Client("http://www.example.com/", { ssl: false })
+        const app = new Test()
+        let error: any
+        try {
+          await client.exec(app.a())
+        } catch (e) {
+          error = e
+        }
+        assert.deepEqual(error, {
+          name: "Error",
+          message: "error!"
+        })
       })
     })
   })


### PR DESCRIPTION
* Make sure 1 method per exec/send
* Use `Promise` error to send error to client in `exec`